### PR TITLE
fix pip install and update README with package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install git+https://github.com/PhracturedBlue/fava-portfolio-summary
 ## Configuration
 In the beancount file, configure via:
 ```
-2000-01-01 custom "fava-extension" "portfolio_summary" "{
+2000-01-01 custom "fava-extension" "fava_portfolio_summary" "{
     'metadata-key': 'portfolio',
     'account-groups': (
         { 'name': 'cash', 'mwr': False },

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setup(
     author_email='rc2012@pblue.org',
     license='MIT',
     keywords='fava beancount accounting investment mwrr mwr twrr twr irr',
-    packages=find_packages(),
+    packages=['fava_portfolio_summary'],
     package_dir={'fava_portfolio_summary': '.'},
+    package_data={'': ['templates/PortfolioSummary.html']},
     include_package_data=True,
     install_requires=[
         'beancount>=2.3.4',


### PR DESCRIPTION
I had to make a few changes to setup.py in order to be able to integrate fava-portfolio-summary into my docker image where run beancount/fava. The Dockerfile is as follows:

```
FROM python:3

# Keeps Python from generating .pyc files in the container
ENV PYTHONDONTWRITEBYTECODE=1

RUN /usr/local/bin/python -m pip install --upgrade pip
RUN /usr/local/bin/python -m pip install --upgrade setuptools
COPY requirements.txt .
RUN python -m pip install -r requirements.txt

WORKDIR /beancount

ENV FAVA_HOST=0.0.0.0
ENV FAVA_PORT=15000
ENV MAIN_FILE=main.beancount

EXPOSE 15000

CMD ["/bin/bash", "-c", "fava $MAIN_FILE"]
```

And requirements.txt contains:
```
fava
git+https://github.com/PhracturedBlue/fava-portfolio-summary
```

The package was being created without the source and template files, so fava was failing to load it. This gets resolved with this proposal.