### PR TITLE
handle KeyError error when getting security prices

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -230,7 +230,10 @@ class PortfolioSummary(FavaExtensionBase):  # pragma: no cover
 
         ### GET LAST CURRENCY PRICE DATE
         if row_currency is not None and row_currency != self.operating_currency:
-            dict_dates = g.ledger.prices(self.operating_currency,row_currency)
+            try:
+                dict_dates = g.ledger.prices(self.operating_currency,row_currency)
+            except KeyError:
+                dict_dates = g.ledger.prices('USD',row_currency)
             if len(dict_dates) >0:
                 row["last-date"] = dict_dates[-1][0]
         return row

--- a/__init__.py
+++ b/__init__.py
@@ -230,6 +230,7 @@ class PortfolioSummary(FavaExtensionBase):  # pragma: no cover
 
         ### GET LAST CURRENCY PRICE DATE
         if row_currency is not None and row_currency != self.operating_currency:
+            #TODO: handle multi currency trades
             try:
                 dict_dates = g.ledger.prices(self.operating_currency,row_currency)
             except KeyError:


### PR DESCRIPTION
I encountered following error when using the extension:
```
Exception on /beancount/extension/PortfolioSummary/ [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/fava_portfolio_summary/__init__.py", line 71, in portfolio_accounts
    portfolio = self._account_metadata_pattern(tree, key, pattern, internal, mwr, twr)
  File "/usr/local/lib/python3.10/site-packages/fava_portfolio_summary/__init__.py", line 172, in _account_metadata_pattern
    portfolio_data = self._portfolio_data(selected_accounts, internal, mwr, twr)
  File "/usr/local/lib/python3.10/site-packages/fava_portfolio_summary/__init__.py", line 263, in _portfolio_data
    rows.append(total)
  File "/usr/local/lib/python3.10/site-packages/fava_portfolio_summary/__init__.py", line 233, in _process_node
    try:
  File "/usr/local/lib/python3.10/site-packages/fava/core/__init__.py", line 538, in prices
    all_prices = get_all_prices(self.price_map, (base, quote))
  File "/usr/local/lib/python3.10/site-packages/beancount/core/prices.py", line 303, in get_all_prices
    return _lookup_price_and_inverse(price_map, base_quote)
  File "/usr/local/lib/python3.10/site-packages/beancount/core/prices.py", line 278, in _lookup_price_and_inverse
    return price_map[base_quote]
KeyError: ('CHF', 'VT')
```

The problem for me is that I have securities which are traded in USD, while my operating currency is CHF. It seems operating currency does not work in the situation where the user needs to trade uisng different currencies. I propose to add this workaround for the time being and later work on a smarter solution to figure out which currency should be used to obtain the prices.