### PR TITLE
Adds allocation breakdown for each portfolio under All portfolios

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -109,7 +109,7 @@ class PortfolioSummaryInstance:  # pragma: no cover
                     row_copy = row.copy()
                     row_copy['account'] = title
                     row_copy['allocation'] = round(100*(float(row['balance'])/float(self.total['balance'])),2)
-                    row_copy['children']
+                    row_copy['children'] = []
                     portfolio_summary.append(row_copy)
         self.total['children'] = portfolio_summary
 

--- a/__init__.py
+++ b/__init__.py
@@ -74,6 +74,18 @@ class PortfolioSummary(FavaExtensionBase):  # pragma: no cover
                 raise Exception from _e
             all_mwr_internal |= internal
             portfolios.append(portfolio)
+
+        #Adds allocation for each portfolio under All portfolios
+        portfolio_summary = []
+        for title, portfolio_data in portfolios:
+            for row in portfolio_data[1]:
+                if row['account'] == 'Total':
+                    row_copy = row.copy()
+                    row_copy['account'] = title
+                    row_copy['allocation'] = round(100*(float(row['balance'])/float(self.total['balance'])),2)
+                    portfolio_summary.append(row_copy)
+        self.total['children'] = portfolio_summary
+
         self.total['change'] = round((float(self.total['balance'] - self.total['cost']) /
                                      (float(self.total['cost'])+.00001)) * 100, 2)
         self.total['PnL'] = round(float(self.total['balance'] - self.total['cost']), 2)


### PR DESCRIPTION
I originally tried out the fava-portfolio-summary extension because I was looking for a simple way to track my stock allocation versus the rest of my portfolio. While associating different accounts to my stocks portfolio, fava-portfolio-summary will show me the percentage of each security under this portfolio but not the percentage of stocks in the whole portfolio. This PR adds this as part of the summary, on the top under All portifolios.

For example, this is how it looks for me with this change: https://paste.pics/GPRDG